### PR TITLE
use ksoup-lite and upgrade agp

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.1"
+agp = "8.5.2"
 android-compileSdk = "34"
 android-minSdk = "14"
 android-minComposeSdk = "21"
@@ -20,7 +20,7 @@ sketchCompose = "4.0.0-alpha08"
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-immutableCollections = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx-immutableCollections" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
-ksoup = { module = "com.fleeksoft.ksoup:ksoup", version.ref = "ksoup" }
+ksoup = { module = "com.fleeksoft.ksoup:ksoup-lite", version.ref = "ksoup" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
 androidx-annotation-jvm = { group = "androidx.annotation", name = "annotation-jvm", version.ref = "annotationJvm" }
 androidx-lifecycle-common = { group = "androidx.lifecycle", name = "lifecycle-common", version.ref = "lifecycleCommon" }


### PR DESCRIPTION
## Pull Request Description

- **Refactor**: Replaced `ksoup` with `ksoup-lite` to eliminate external IO and network dependencies. This change is intended because `ksoup-lite` is sufficient for string parsing, removing the need for `kotlinx` and `ktor` dependencies.
- **Upgrade**: Updated Android Gradle Plugin (AGP) to version **8.5.2** for improved compatibility and performance.

This refactor reduces unnecessary dependencies, making the project more lightweight and efficient.